### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+td2planet (0.3.0-2) UNRELEASED; urgency=medium
+
+  * Apply multi-arch hints.
+    + td2planet: Add :any qualifier for ruby dependency.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 27 Oct 2020 19:40:00 -0000
+
 td2planet (0.3.0-1) unstable; urgency=medium
 
   [ Yukiharu YABUKI ]

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ XS-Ruby-Versions: all
 Package: td2planet
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ruby | ruby-interpreter,
+Depends: ruby:any | ruby-interpreter,
          ${misc:Depends}
 Recommends: tdiary-theme
 Description: Ruby-based server-side blog aggregator


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* td2planet: Add :any qualifier for ruby dependency. This fixes: td2planet could have its dependency on ruby annotated with :any. ([dep-any](https://wiki.debian.org/MultiArch/Hints#dep-any))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/td2planet/e7a08057-b156-4e9b-bb53-8055717f2217.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Depends: [-ruby-] {+ruby:any+} | ruby-interpreter


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/e7a08057-b156-4e9b-bb53-8055717f2217/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/e7a08057-b156-4e9b-bb53-8055717f2217/diffoscope)).
