### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ XB-Ruby-Versions: ${ruby:Versions}
 Depends: ruby:any | ruby-interpreter,
          ${misc:Depends}
 Recommends: tdiary-theme
+Multi-Arch: foreign
 Description: Ruby-based server-side blog aggregator
  This package is a server-side blog aggregator (commonly called a
  'planet') which is well-suited for aggregating tDiary-based blogs.


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.

Note that in some cases, these multi-arch hints may trigger lintian warnings
until the dependencies of the package support multi-arch. This is expected,
see [/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.



This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/td2planet/10bda502-4353-4c1b-a0b3-b5ea121317eb.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/10bda502-4353-4c1b-a0b3-b5ea121317eb/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/10bda502-4353-4c1b-a0b3-b5ea121317eb/diffoscope)).
