### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 td2planet (0.3.0-5) UNRELEASED; urgency=medium
 
   * Use secure URI in Homepage field.
+  * Bump debhelper from old 12 to 13.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 29 Sep 2022 13:35:26 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+td2planet (0.3.0-5) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 29 Sep 2022 13:35:26 -0000
+
 td2planet (0.3.0-4) unstable; urgency=medium
 
   [ Yukiharu YABUKI ]

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: td2planet
 Section: ruby
 Priority: optional
 Maintainer: Yukiharu YABUKI <yyabuki@debian.org>
-Build-Depends: debhelper-compat (= 12), gem2deb (>= 0.3.0~)
+Build-Depends: debhelper-compat (= 13), gem2deb (>= 0.3.0~)
 Build-Depends-Indep: ruby | ruby-interpreter
 Standards-Version: 3.9.5
 Homepage: https://github.com/znz/td2planet/

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Yukiharu YABUKI <yyabuki@debian.org>
 Build-Depends: debhelper-compat (= 12), gem2deb (>= 0.3.0~)
 Build-Depends-Indep: ruby | ruby-interpreter
 Standards-Version: 3.9.5
-Homepage: http://github.com/znz/td2planet/
+Homepage: https://github.com/znz/td2planet/
 Vcs-Browser: https://github.com/yabuki/td2planet
 Vcs-Git: https://github.com/yabuki/td2planet.git
 XS-Ruby-Versions: all


### PR DESCRIPTION
Fix some issues reported by lintian

* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri))

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/td2planet/2752252a-9f70-4831-a0b2-e8b578bcf34e.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Homepage: [-http&#8203;://github.com/znz/td2planet/-] {+https&#8203;://github.com/znz/td2planet/+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/2752252a-9f70-4831-a0b2-e8b578bcf34e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/2752252a-9f70-4831-a0b2-e8b578bcf34e/diffoscope)).
